### PR TITLE
Update NuGet package publishing process

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,6 +5,7 @@ permissions:
 on:
   release:
     types: [published]
+  workflow_dispatch: 
 
 env:
   configuration: Release

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -123,6 +123,14 @@ jobs:
       - name: Create NuGet package
         run: dotnet pack ./sources/EngageLabs.MinimalApi/EngageLabs.MinimalApi.csproj --configuration ${{ env.configuration }} --no-build --no-restore --output ./nuget
 
-      - name: Publish NuGet package
-        run: dotnet nuget push ./nuget/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }} # Recommended: use a secret like ${{ secrets.NUGET_USER }} for your nuget.org username (profile name), NOT your email address
+    
+      # Push the package
+      - name: NuGet push
+        run: dotnet nuget push artifacts/my-sdk.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: 
 
 env:
   configuration: Release


### PR DESCRIPTION
Replaced direct NuGet push with OIDC login for temporary API key.